### PR TITLE
Improve initial VCS matching

### DIFF
--- a/pacvcs
+++ b/pacvcs
@@ -21,8 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE. 
 
-set -x
-
 readonly systems="cvs |svn |hg |bzr |git "
 
 readonly esc="\033["

--- a/pacvcs
+++ b/pacvcs
@@ -21,8 +21,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE. 
 
+set -x
 
-readonly systems="cvs|svn|hg|bzr|git"
+readonly systems="cvs |svn |hg |bzr |git "
 
 readonly esc="\033["
 readonly red="${esc}0;31m"
@@ -33,7 +34,7 @@ readonly NC="${esc}0m"
 
 
 #loop over each output
-pacman -Qm | grep -E "$systems" | while read -r line ; do
+pacman -Qm | grep -E "${systems}" | while read -r line; do
     status_color="${yellow}"
     
     


### PR DESCRIPTION
Reduce false positives when matching package names with VCS strings by searching for the pattern "$VCS ".

Example:
![lenovo-1661426837](https://user-images.githubusercontent.com/6384581/186653767-d97d59bb-997b-4014-a6d4-aaa74dfd31e7.jpg)
